### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
 [[TattleControl sharedControl] enableTattleToWindow:self.window]; 
 ```
 
-### From Cocoapods
+### From CocoaPods
 * Podfile 
 ```ruby
 platform :ios, '6.0'
@@ -88,7 +88,7 @@ self.window = UIWindow(frame: UIScreen.mainScreen().bounds)
 TattleControl.sharedControl().enableTattleToWindow(self.window)
 ```
 
-### From Cocoapods
+### From CocoaPods
 * Podfile 
 ```ruby
 platform :ios, '6.0'


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>

Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
